### PR TITLE
Closed-book exam functionality

### DIFF
--- a/api.go
+++ b/api.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("Cannot parse duration Got: %v", err)
 	}
 
-    playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: "freecompilercamp/pwc:full", AvailableDinDInstanceImages: []string{"freecompilercamp/pwc:18.04","freecompilercamp/pwc:16.04","freecompilercamp/pwc:full", "freecompilercamp/pwc:rose-debug", "freecompilercamp/pwc:rose-bug", "freecompilercamp/pwc:rose-test", "freecompilercamp/pwc:llvm10","fcc_docker:test"}, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, Extras: map[string]interface{}{"LoginRedirect": "http://localhost:3000"}}
+    playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: "freecompilercamp/pwc:full", AvailableDinDInstanceImages: []string{"freecompilercamp/pwc:18.04","freecompilercamp/pwc:16.04","freecompilercamp/pwc:full", "freecompilercamp/pwc:rose-debug", "freecompilercamp/pwc:rose-bug", "freecompilercamp/pwc:rose-exam", "freecompilercamp/pwc:llvm10","fcc_docker:test"}, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, Extras: map[string]interface{}{"LoginRedirect": "http://localhost:3000"}}
 	if _, err := core.PlaygroundNew(playground); err != nil {
 		log.Fatalf("Cannot create default playground. Got: %v", err)
 	}

--- a/api.go
+++ b/api.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("Cannot parse duration Got: %v", err)
 	}
 
-    playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: "freecompilercamp/pwc:full", AvailableDinDInstanceImages: []string{"freecompilercamp/pwc:18.04","freecompilercamp/pwc:16.04","freecompilercamp/pwc:full", "freecompilercamp/pwc:rose-debug", "freecompilercamp/pwc:rose-bug","freecompilercamp/pwc:llvm10","fcc_docker:test"}, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, Extras: map[string]interface{}{"LoginRedirect": "http://localhost:3000"}}
+    playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: "freecompilercamp/pwc:full", AvailableDinDInstanceImages: []string{"freecompilercamp/pwc:18.04","freecompilercamp/pwc:16.04","freecompilercamp/pwc:full", "freecompilercamp/pwc:rose-debug", "freecompilercamp/pwc:rose-bug", "freecompilercamp/pwc:rose-test", "freecompilercamp/pwc:llvm10","fcc_docker:test"}, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, Extras: map[string]interface{}{"LoginRedirect": "http://localhost:3000"}}
 	if _, err := core.PlaygroundNew(playground); err != nil {
 		log.Fatalf("Cannot create default playground. Got: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ var PlaygroundDomain string
 
 var SegmentId string
 
+var TestEndpoint string // endpoint for hosting closed-book test content
+
 // TODO move this to a sync map so it can be updated on demand when the configuration for a playground changes
 var Providers = map[string]map[string]*oauth2.Config{}
 
@@ -55,10 +57,12 @@ func ParseFlags() {
 	flag.StringVar(&CookieHashKey, "cookie-hash-key", "", "Hash key to use to validate cookies")
 	flag.StringVar(&CookieBlockKey, "cookie-block-key", "", "Block key to use to encrypt cookies")
 
-    flag.StringVar(&PlaygroundDomain, "playground-domain", "lab.freecompilercamp.org:5010", "Domain to use for the playground")
+	flag.StringVar(&PlaygroundDomain, "playground-domain", "lab.freecompilercamp.org:5010", "Domain to use for the playground")
 	flag.StringVar(&AdminToken, "admin-token", "", "Token to validate admin user for admin endpoints")
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
+
+	flag.StringVar(&TestEndpoint, "test-endpoint", "http://192.168.64.2/llnl-freecompilercamp/freecc_tests/", "Resource host endpoint for closed-book testing")
 
 	flag.Parse()
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ var PlaygroundDomain string
 
 var SegmentId string
 
-var TestEndpoint string // endpoint for hosting closed-book test content
+var ExamEndpoint string // endpoint for hosting closed-book test content
 
 // TODO move this to a sync map so it can be updated on demand when the configuration for a playground changes
 var Providers = map[string]map[string]*oauth2.Config{}
@@ -62,7 +62,7 @@ func ParseFlags() {
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
 
-	flag.StringVar(&TestEndpoint, "test-endpoint", "http://192.168.64.2/llnl-freecompilercamp/freecc_tests/", "Resource host endpoint for closed-book testing")
+	flag.StringVar(&ExamEndpoint, "exam-endpoint", "http://192.168.64.2/llnl-freecompilercamp/freecc_tests/", "Resource host endpoint for closed-book exams")
 
 	flag.Parse()
 

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func ParseFlags() {
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
 
-	flag.StringVar(&ExamEndpoint, "exam-endpoint", "http://192.168.64.2/llnl-freecompilercamp/freecc_tests/", "Resource host endpoint for closed-book exams")
+	flag.StringVar(&ExamEndpoint, "exam-endpoint", "http://ec2-54-241-120-89.us-west-1.compute.amazonaws.com/llnl-freecompilercamp/freecc_exams/", "Resource host endpoint for closed-book exams")
 
 	flag.Parse()
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -221,7 +221,8 @@ func (d *docker) CopyToContainer(containerName, destination, fileName string, co
 	}
 	t := tar.NewWriter(w)
 	go func() {
-		t.WriteHeader(&tar.Header{Name: fileName, Mode: 0600, Size: int64(len(b)), ModTime: time.Now()})
+		// Have to use uid and gid rather than uname and gname. FreeCC user uid and gid is 9999.
+		t.WriteHeader(&tar.Header{Name: fileName, Mode: 0600, Size: int64(len(b)), Uid: 9999, Gid: 9999, ModTime: time.Now()})
 		t.Write(b)
 		t.Close()
 		w.Close()

--- a/dockerfiles/dind/Dockerfile.rose-test
+++ b/dockerfiles/dind/Dockerfile.rose-test
@@ -144,8 +144,8 @@ RUN alias ls='ls --color=auto'
 
 RUN mkdir $ROSE_SRC/freecc_tests
 
-# Move to our home
-WORKDIR /home/freecc
+# Move to the testing directory
+WORKDIR /home/freecc/source/rose_src/freecc_tests
 
 # Setup certs and ssh keys
 RUN mkdir ~/.ssh && ssh-keygen -N "" -t rsa -f ~/.ssh/id_rsa \

--- a/dockerfiles/dind/Dockerfile.rose-test
+++ b/dockerfiles/dind/Dockerfile.rose-test
@@ -1,0 +1,154 @@
+# This dockerfile is a version of ROSE for online closed-book testing.
+# The only additional thing it does is add a directory for submissions at present.
+# However, future work may need to add other things, so we provide this special image.
+
+FROM freecompilercamp/pwc:middle
+
+RUN apt-get update && \
+    apt-get -y install git tmux python-pip apache2-utils vim build-essential gettext curl bash-completion bash util-linux jq openssh-client openssl tree cmake man
+
+# Adding user freecc
+RUN groupadd -g 9999 freecc && \
+    useradd -r -u 9999 -g freecc -m -d /home/freecc freecc
+
+ENV GOPATH /home/freecc/go
+ENV PATH $PATH:$GOPATH
+
+# Install httping
+RUN apt-get -y install httping
+
+# Install ROSE pre-requisite
+RUN apt-get install -y \
+        apt-utils \
+        dialog \
+        software-properties-common
+# Install Java JDK
+RUN apt-get install -y openjdk-8-jdk
+# Install ROSE dependency
+RUN apt-get install -y \
+        autoconf \
+        automake \
+        autotools-dev \
+        bc \
+        binutils \
+        bison \
+        build-essential \
+        cmake \
+        cpufrequtils \
+        curl \
+        device-tree-compiler \
+        dkms \
+        doxygen \
+        flex \
+        gawk \
+        gcc-multilib \
+        gdb \
+        gfortran \
+        ghostscript \
+        git \
+        gperf \
+        graphviz \
+        libboost-all-dev \
+        libgmp-dev \
+        libhpdf-dev \
+        libmpc-dev \
+        libmpfr-dev \
+        libomp-dev \
+        libtool \
+        libxml2-dev \
+        patchutils \
+        perl-doc \
+        python3-dev \
+        sqlite \
+        texinfo \
+        unzip \
+        vim \
+        wget \
+        zip \
+        zlib1g \
+        zlib1g-dev \
+        ninja-build && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/*
+
+ENV DOCKERAPP_VERSION=v0.8.0
+ENV COMPOSE_VERSION=1.23.2
+# Install Compose and Machine
+RUN pip install docker-compose==${COMPOSE_VERSION}
+
+RUN curl -fsSL --output /tmp/docker-app-linux.tar.gz https://github.com/docker/app/releases/download/${DOCKERAPP_VERSION}/docker-app-linux.tar.gz \
+    && tar xf "/tmp/docker-app-linux.tar.gz" -C /tmp/ && mkdir -p /root/.docker/cli-plugins && mv /tmp/docker-app-plugin-linux /root/.docker/cli-plugins/docker-app && rm /tmp/docker-app*
+
+# Add bash completion and set bash as default shell
+#RUN mkdir /etc/bash_completion.d \
+RUN curl https://raw.githubusercontent.com/docker/cli/master/contrib/completion/bash/docker -o /etc/bash_completion.d/docker \
+    && sed -i "s/ash/bash/" /etc/passwd
+
+# Replace modprobe with a no-op to get rid of spurious warnings
+# (note: we can't just symlink to /bin/true because it might be busybox)
+#RUN rm /sbin/modprobe && echo '#!/bin/true' >/sbin/modprobe && chmod +x /sbin/modprobe
+RUN echo '#!/bin/true' > /sbin/modprobe && chmod +x /sbin/modprobe
+
+# Install a nice vimrc file and prompt (by soulshake)
+COPY ["docker-prompt", "sudo", "/usr/local/bin/"]
+COPY ["motd", "/etc/motd"]
+COPY ["daemon.json", "/etc/docker/"]
+
+# Remove IPv6 alias for localhost and start docker in the background ...
+CMD cat /etc/hosts > /home/freecc/.hosts.bak && \
+    sed 's/^::1.*//' /home/freecc/.hosts.bak > /etc/hosts && \
+    sed -i "s/\PWD_IP_ADDRESS/$PWD_IP_ADDRESS/" /etc/docker/daemon.json && \
+    sed -i "s/\DOCKER_TLSENABLE/$DOCKER_TLSENABLE/" /etc/docker/daemon.json && \
+    sed -i "s/\DOCKER_TLSCACERT/$DOCKER_TLSCACERT/" /etc/docker/daemon.json && \
+    sed -i "s/\DOCKER_TLSCERT/$DOCKER_TLSCERT/" /etc/docker/daemon.json && \
+    sed -i "s/\DOCKER_TLSKEY/$DOCKER_TLSKEY/" /etc/docker/daemon.json && \
+    mount -t securityfs none /sys/kernel/security && \
+    echo "root:root" | chpasswd &> /dev/null && \
+    /usr/sbin/sshd -o PermitRootLogin=yes -o PrintMotd=no 2>/dev/null && \
+    dockerd &> /home/freecc/.docker.log & \
+    while true ; do script -q -c "/bin/bash -l" /dev/null ; done
+# ... and then put a shell in the foreground, restarting it if it exits
+
+# Setup certs and ssh keys
+RUN mkdir -p /var/run/pwd/certs && mkdir -p /var/run/pwd/uploads \
+    && ssh-keygen -N "" -t rsa -f  /etc/ssh/ssh_host_rsa_key >/dev/null
+
+# Switch user to freecc
+USER freecc
+
+# Install ROSE
+# Prepare installation
+ENV ROSE_SRC /home/freecc/source/rose_src
+ENV ROSE_PATH /home/freecc/install/rose_install
+ENV ROSE_BUILD /home/freecc/build/rose_build
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV LD_LIBRARY_PATH $JAVA_HOME/jre/lib/amd64/server:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+RUN mkdir -p $ROSE_PATH && \
+    mkdir -p $ROSE_BUILD && \
+    git clone https://github.com/rose-compiler/rose.git $ROSE_SRC && \
+    cd $ROSE_SRC && \
+    ./build && \
+    cd $ROSE_BUILD && \
+    sudo $ROSE_SRC/configure --prefix=$ROSE_PATH --with-boost=/usr --with-boost-libdir=/usr/lib/x86_64-linux-gnu/ --enable-languages=c,c++,fortran --enable-projects-directory --disable-tests-directory --disable-tutorial-directory --enable-edg_version=5.0 --with-gomp_omp_runtime_library=/usr/lib/gcc/x86_64-linux-gnu/7
+# Compile ROSE
+RUN cd $ROSE_BUILD && \
+    sudo make core -j4 && \
+    sudo make install-core
+# Setup ROSE environment
+ENV PATH $ROSE_PATH/bin:$PATH
+ENV LD_LIBRARY_PATH $ROSE_PATH/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH $ROSE_PATH/lib:$LIBRARY_PATH
+ENV MANPATH $ROSE_PATH/share/man:$MANPATH
+RUN alias ls='ls --color=auto'
+
+RUN mkdir $ROSE_SRC/freecc_tests
+
+# Move to our home
+WORKDIR /home/freecc
+
+# Setup certs and ssh keys
+RUN mkdir ~/.ssh && ssh-keygen -N "" -t rsa -f ~/.ssh/id_rsa \
+    && cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
+
+COPY [".vimrc", ".profile", ".inputrc", ".gitconfig", "/home/freecc/"]

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -68,6 +68,7 @@ func Register(extend HandlerExtender) {
 	}), gh.AllowedOrigins([]string{}))
 
 	// Specific routes
+	// "testuploads" endpoint added for closed-book testing in PWC
 	r.HandleFunc("/ping", Ping).Methods("GET")
 	corsRouter.HandleFunc("/instances/images", GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", GetSession).Methods("GET")
@@ -76,6 +77,7 @@ func Register(extend HandlerExtender) {
 	corsRouter.HandleFunc("/sessions/{sessionId}/setup", SessionSetup).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances", NewInstance).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/uploads", FileUpload).Methods("POST")
+	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/testuploads", TestUpload).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}", DeleteInstance).Methods("DELETE")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/exec", Exec).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/fstree", fsTree).Methods("GET")

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -68,7 +68,7 @@ func Register(extend HandlerExtender) {
 	}), gh.AllowedOrigins([]string{}))
 
 	// Specific routes
-	// "testuploads" endpoint added for closed-book testing in PWC
+	// "examuploadcompile" endpoint added for closed-book exams in PWC
 	r.HandleFunc("/ping", Ping).Methods("GET")
 	corsRouter.HandleFunc("/instances/images", GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", GetSession).Methods("GET")
@@ -77,7 +77,7 @@ func Register(extend HandlerExtender) {
 	corsRouter.HandleFunc("/sessions/{sessionId}/setup", SessionSetup).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances", NewInstance).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/uploads", FileUpload).Methods("POST")
-	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/testuploads", TestUpload).Methods("POST")
+	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/examuploadcompile", ExamUploadCompile).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}", DeleteInstance).Methods("DELETE")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/exec", Exec).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/fstree", fsTree).Methods("GET")

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -68,7 +68,7 @@ func Register(extend HandlerExtender) {
 	}), gh.AllowedOrigins([]string{}))
 
 	// Specific routes
-	// "examuploadcompile" endpoint added for closed-book exams in PWC
+	// "examuploadcompile" and "examrun" endpoint added for closed-book exams in PWC
 	r.HandleFunc("/ping", Ping).Methods("GET")
 	corsRouter.HandleFunc("/instances/images", GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", GetSession).Methods("GET")
@@ -78,6 +78,7 @@ func Register(extend HandlerExtender) {
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances", NewInstance).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/uploads", FileUpload).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/examuploadcompile", ExamUploadCompile).Methods("POST")
+	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/examrun", ExamRun).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}", DeleteInstance).Methods("DELETE")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/exec", Exec).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}/fstree", fsTree).Methods("GET")

--- a/handlers/exam_run.go
+++ b/handlers/exam_run.go
@@ -1,0 +1,105 @@
+/*
+* Specialized version of exec that is intended to run uploaded code.
+* It does the following:
+*   - Checks to make sure that the exam has already been uploaded AND compiled.
+*   - Runs the make check target in the corresponding Makefile.
+*/
+
+package handlers
+
+import (
+  "strings"
+	"io"
+	"log"
+	"net/http"
+  "encoding/json"
+  "fmt"
+
+	"github.com/gorilla/mux"
+	"github.com/play-with-docker/play-with-docker/storage"
+)
+
+func ExamRun(rw http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  sessionId := vars["sessionId"]
+  instanceName := vars["instanceName"]
+
+  s, err := core.SessionGet(sessionId)
+  if err == storage.NotFoundError {
+    rw.WriteHeader(http.StatusNotFound)
+    return
+  } else if err != nil {
+    rw.WriteHeader(http.StatusInternalServerError)
+    return
+  }
+  i := core.InstanceGet(s, instanceName)
+
+  examName := req.URL.Query().Get("examname")
+
+  // Step 1: Make sure the uploaded code has been compiled.
+  var lsCmd = fmt.Sprintf(
+    `{ "command": ["ls", "%s"] }`,
+    examName + "_submission")
+
+  var er1 execRequest // from exec.go handler
+
+  err = json.NewDecoder(strings.NewReader(lsCmd)).Decode(&er1)
+  if err != nil {
+    log.Fatal(err)
+    rw.WriteHeader(http.StatusBadRequest)
+    return
+  }
+
+  cmdout, err := core.InstanceExecOutput(i, er1.Cmd)
+
+  if err != nil {
+    log.Printf("Error executing command; error: %s, cmdout: %s", err, cmdout)
+    rw.WriteHeader(http.StatusInternalServerError)
+    return
+  }
+
+  buf := new(strings.Builder)
+  io.Copy(buf, cmdout)
+
+  // If ls returns "No such file or directory" for the test name executable,
+  // then it has not been successfully compiled. Respond with 404 NOT FOUND.
+  // Otherwise, we can continue to step 2.
+  if strings.Contains(buf.String(), "No such file or directory") {
+    rw.WriteHeader(http.StatusNotFound)
+    return
+  }
+
+  // Step 2: Run the make check target
+  var makeCheckCmd = `{ "command": ["make", "check"] }`
+
+  var er2 execRequest // from exec.go handler
+
+  err = json.NewDecoder(strings.NewReader(makeCheckCmd)).Decode(&er2)
+  if err != nil {
+    log.Fatal(err)
+    rw.WriteHeader(http.StatusInternalServerError)
+    return
+  }
+
+  // Step 2.5: Check if make compilation was successful
+
+  cmdout2, err := core.InstanceExecOutput(i, er2.Cmd)
+
+  if err != nil {
+    log.Printf("Error executing command; error: %s, cmdout: %s", err, cmdout)
+    rw.WriteHeader(http.StatusInternalServerError)
+    return
+  }
+
+  rw.Header().Set("content-type", "text/html")
+
+  if _,err = io.Copy(rw, cmdout2); err != nil {
+    log.Println(err)
+    rw.WriteHeader(http.StatusInternalServerError)
+    return
+  }
+
+  rw.WriteHeader(http.StatusOK)
+  return
+
+}

--- a/handlers/exam_upload_compile.go
+++ b/handlers/exam_upload_compile.go
@@ -146,11 +146,11 @@ func ExamUploadCompile(rw http.ResponseWriter, req *http.Request) {
   io.Copy(buf, cmdout)
   log.Println(buf.String())
 
-  // Parses the make response the word "Error" that shows when make fails.
+  // Parses the make response the word "Error" or "Stop" that shows when make fails.
   // If there is an error, send it back with the HTTP response. Else, send success.
   // NOTE: We send back a 502 (Bad Gateway) on compile error, along with the error(s).
   // Client should handle this appropriately (check if 502 and print error)
-  if strings.Contains(buf.String(), "Error") {
+  if strings.Contains(buf.String(), "Error") || strings.Contains(buf.String(), "Stop") {
     comperr := strings.NewReader(buf.String())
     rw.WriteHeader(http.StatusBadGateway)
     if _,err = io.Copy(rw, comperr); err != nil {

--- a/handlers/exam_upload_compile.go
+++ b/handlers/exam_upload_compile.go
@@ -23,7 +23,7 @@ import (
 	"github.com/play-with-docker/play-with-docker/storage"
 )
 
-func TestUpload(rw http.ResponseWriter, req *http.Request) {
+func ExamUploadCompile(rw http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	sessionId := vars["sessionId"]
 	instanceName := vars["instanceName"]
@@ -75,27 +75,27 @@ func TestUpload(rw http.ResponseWriter, req *http.Request) {
 
 	// Step 1.5: Grab resources from server/endpoint
 
-  // Grab the test name that we will use to match the directory at the host endpoint
-  testName := req.URL.Query().Get("testname")
+  // Grab the exam name that we will use to match the directory at the host endpoint
+  examName := req.URL.Query().Get("examname")
 
   // Get the cut length from the resource host endpoint. We need this for wget.
   // If the endpoint contains http or https, we ignore that.
   // e.g.: if the endpoint is https://localhost/llnl-freecompilercamp/freecc_tests/
   // the cutlength is 3.
-  var cutlen = strings.Count(config.TestEndpoint, "/")
-  if strings.Contains(config.TestEndpoint, "http") || strings.Contains(config.TestEndpoint, "https") {
+  var cutlen = strings.Count(config.ExamEndpoint, "/")
+  if strings.Contains(config.ExamEndpoint, "http") || strings.Contains(config.ExamEndpoint, "https") {
     cutlen = cutlen - 2
   }
 
-  // NOTE: The default WORKDIR set by the special rose-test and llvm-test images
+  // NOTE: The default WORKDIR set by the special rose-exam and llvm-exam images
   // is the directory where code is uploaded. All of the commands below are
   // executed in that directory implicitly (no need to cd)
-  // cutlen + 1 because it includes the folder for this specific test.
+  // cutlen + 1 because it includes the folder for this specific exam.
   var wgetCmd = fmt.Sprintf(
     `{ "command":
     ["wget", "-r", "-np", "-R", "index.html*", "-nH", "--cut-dirs=%d",
     "%s/%s/"] }`,
-    cutlen + 1, config.TestEndpoint, testName)
+    cutlen + 1, config.ExamEndpoint, examName)
 
   var er1 execRequest // from exec.go handler
 
@@ -114,7 +114,7 @@ func TestUpload(rw http.ResponseWriter, req *http.Request) {
     return
   }
 
-  log.Printf("Obtained test resources from endpoint.")
+  log.Printf("Obtained exam resources from endpoint.")
 
 
   // Step 2: Compile via make

--- a/handlers/test_upload.go
+++ b/handlers/test_upload.go
@@ -1,0 +1,81 @@
+/*
+* Specialized version of file_upload that is intended to upload code.
+* It does the following:
+*   - Uploads the code to the instance via the multipart form data
+*   - Compiles the code
+*   - Runs test cases on the code
+*   - Once all are done, runs the test cases on the compiled code
+*   - Returns an HTTP response once the above steps are completed, or the first
+*       error encountered
+*/
+
+package handlers
+
+import (
+  "strings"
+	"io"
+	"log"
+	"net/http"
+  "encoding/json"
+
+	"github.com/gorilla/mux"
+	"github.com/play-with-docker/play-with-docker/storage"
+)
+
+func TestUpload(rw http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	sessionId := vars["sessionId"]
+	instanceName := vars["instanceName"]
+
+  // Step 1: upload the code to the instance
+
+	s, err := core.SessionGet(sessionId)
+	if err == storage.NotFoundError {
+		rw.WriteHeader(http.StatusNotFound)
+		return
+	} else if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	i := core.InstanceGet(s, instanceName)
+
+	// allow up to 32 MB which is the default
+
+	red, err := req.MultipartReader()
+	if err != nil {
+		log.Println(err)
+		rw.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	path := req.URL.Query().Get("path")
+
+	for {
+		p, err := red.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		if p.FileName() == "" {
+			continue
+		}
+		err = core.InstanceUploadFromReader(i, p.FileName(), path, p)
+		if err != nil {
+			log.Println(err)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("Uploaded [%s] to [%s]\n", p.FileName(), i.Name)
+
+		// Step 2: compile the code
+    // TODO
+
+	}
+	rw.WriteHeader(http.StatusOK)
+	return
+
+}

--- a/provisioner/dind.go
+++ b/provisioner/dind.go
@@ -152,7 +152,7 @@ func (d *DinD) InstanceExec(instance *types.Instance, cmd []string) (int, error)
 }
 
 // For PWC closed-book testing, like InstanceExec except returns the output of
-// command.
+// command. Can also return any errors (stdout or stderr supported)
 func (d *DinD) InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error) {
 	session, err := d.getSession(instance.SessionId)
 	if err!= nil {
@@ -166,7 +166,7 @@ func (d *DinD) InstanceExecOutput(instance *types.Instance, cmd []string) (io.Re
 
 	if c,err := dockerClient.ExecAttach(instance.Name, cmd, b); c > 0 {
 		log.Println(b.String())
-		return nil, fmt.Errorf("Error %d trying to run command", c)
+		//return nil, fmt.Errorf("Error %d trying to run command", c)
 	} else if err != nil {
 		return nil, err
 	}

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -19,6 +19,7 @@ type InstanceProvisionerApi interface {
 	InstanceNew(session *types.Session, conf types.InstanceConfig) (*types.Instance, error)
 	InstanceDelete(session *types.Session, instance *types.Instance) error
 	InstanceExec(instance *types.Instance, cmd []string) (int, error)
+	InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error)
 	InstanceFSTree(instance *types.Instance) (io.Reader, error)
 	InstanceFile(instance *types.Instance, filePath string) (io.Reader, error)
 

--- a/provisioner/windows.go
+++ b/provisioner/windows.go
@@ -155,6 +155,10 @@ func (d *windows) InstanceExec(instance *types.Instance, cmd []string) (int, err
 	return ex.ExitCode, nil
 }
 
+func (d *windows) InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error) {
+	return nil, nil
+}
+
 func (d *windows) InstanceFSTree(instance *types.Instance) (io.Reader, error) {
 	//TODO implement
 	return nil, nil

--- a/pwd/instance.go
+++ b/pwd/instance.go
@@ -140,6 +140,16 @@ func (p *pwd) InstanceExec(instance *types.Instance, cmd []string) (int, error) 
 	return exitCode, nil
 }
 
+func (p *pwd) InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error) {
+	defer observeAction("InstanceExecOutput", time.Now())
+
+	prov, err := p.getProvisioner(instance.Type)
+	if err != nil {
+		return nil, err
+	}
+	return prov.InstanceExecOutput(instance, cmd)
+}
+
 func (p *pwd) InstanceFSTree(instance *types.Instance) (io.Reader, error) {
 	defer observeAction("InstanceFSTree", time.Now())
 

--- a/pwd/mock.go
+++ b/pwd/mock.go
@@ -87,6 +87,11 @@ func (m *Mock) InstanceExec(instance *types.Instance, cmd []string) (int, error)
 	return args.Int(0), args.Error(1)
 }
 
+func (m *Mock) InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error) {
+	args := m.Called(instance, cmd)
+	return args.Get(0).(io.Reader), args.Error(1)
+}
+
 func (m *Mock) InstanceFSTree(instance *types.Instance) (io.Reader, error) {
 	args := m.Called(instance)
 	return args.Get(0).(io.Reader), args.Error(1)

--- a/pwd/pwd.go
+++ b/pwd/pwd.go
@@ -83,6 +83,7 @@ type PWDApi interface {
 	InstanceFindBySession(session *types.Session) ([]*types.Instance, error)
 	InstanceDelete(session *types.Session, instance *types.Instance) error
 	InstanceExec(instance *types.Instance, cmd []string) (int, error)
+	InstanceExecOutput(instance *types.Instance, cmd []string) (io.Reader, error)
 	InstanceFSTree(instance *types.Instance) (io.Reader, error)
 	InstanceFile(instance *types.Instance, filePath string) (io.Reader, error)
 


### PR DESCRIPTION
This is all the changes I've made to the PWC side for adding closed-book exam functionality to FreeCC.

In summary:

- Added two new HTTP endpoints and their handlers for uploading code (and compiling it after uploading) and running the command to run test cases on that compiled code.
- Added a custom function that returns the output of commands being executed in a Docker container, rather than just a status code as in the normal PWD.
- Added a special ROSE image that is used for closed-book exams. Currently, it just adds a directory and sets the WORKDIR to that directory. But in the future we may need to add additional features that need the image. Image has already been uploaded to Dockerhub. We will need to do the same with Clang at some point.
- In the config, added a URL from where the resources for closed-book exams will be obtained. Currently, this is using a temporary URL that I am hosting on an AWS instance. We will need to change it to the AWS server running FreeCC at some point. It is a one line change and is the only change required for deploying closed-book exams to PWC.